### PR TITLE
Refactor book deletion to use query param and BaseBookResponse

### DIFF
--- a/server/api/Controllers/BookController.cs
+++ b/server/api/Controllers/BookController.cs
@@ -34,8 +34,8 @@ public class BookController(IService<BaseBookResponse, CreateBookDto, UpdateBook
     }
     
     [HttpDelete(nameof(DeleteBook))]
-    public Book DeleteBook([FromBody] string id)
+    public async Task<BaseBookResponse> DeleteBook([FromQuery] string id)
     {
-        throw new NotImplementedException();
+        return await bookService.Delete(id);
     }
 }

--- a/server/api/openapi-with-docs.json
+++ b/server/api/openapi-with-docs.json
@@ -264,7 +264,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Book"
+                  "$ref": "#/components/schemas/BaseBookResponse"
                 }
               }
             }
@@ -278,25 +278,23 @@
           "Book"
         ],
         "operationId": "Book_DeleteBook",
-        "requestBody": {
-          "x-name": "id",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "string"
-              }
-            }
-          },
-          "required": true,
-          "x-position": 1
-        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Book"
+                  "$ref": "#/components/schemas/BaseBookResponse"
                 }
               }
             }
@@ -392,6 +390,10 @@
             "type": "string",
             "nullable": true
           },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
           "genre": {
             "nullable": true,
             "oneOf": [
@@ -467,6 +469,10 @@
             "type": "string",
             "nullable": true
           },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
           "authorsIDs": {
             "type": "array",
             "items": {
@@ -493,6 +499,10 @@
             "type": "string",
             "nullable": true
           },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
           "authorsIDs": {
             "type": "array",
             "items": {
@@ -511,6 +521,30 @@
           "id": {
             "type": "string",
             "minLength": 2
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pages": {
+            "type": "integer",
+            "format": "int32",
+            "maximum": 2147483647.0,
+            "minimum": 1.0
+          },
+          "genreid": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorsIDs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/server/client/src/LibAPI.ts
+++ b/server/client/src/LibAPI.ts
@@ -316,7 +316,7 @@ export class BookClient {
         return Promise.resolve<BaseBookResponse>(null as any);
     }
 
-    updateBook(dto: UpdateBookDto): Promise<Book> {
+    updateBook(dto: UpdateBookDto): Promise<BaseBookResponse> {
         let url_ = this.baseUrl + "/UpdateBook";
         url_ = url_.replace(/[?&]$/, "");
 
@@ -336,13 +336,13 @@ export class BookClient {
         });
     }
 
-    protected processUpdateBook(response: Response): Promise<Book> {
+    protected processUpdateBook(response: Response): Promise<BaseBookResponse> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
-            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as Book;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as BaseBookResponse;
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -350,20 +350,20 @@ export class BookClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<Book>(null as any);
+        return Promise.resolve<BaseBookResponse>(null as any);
     }
 
-    deleteBook(id: string): Promise<Book> {
-        let url_ = this.baseUrl + "/DeleteBook";
+    deleteBook(id: string | undefined): Promise<BaseBookResponse> {
+        let url_ = this.baseUrl + "/DeleteBook?";
+        if (id === null)
+            throw new globalThis.Error("The parameter 'id' cannot be null.");
+        else if (id !== undefined)
+            url_ += "id=" + encodeURIComponent("" + id) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
-        const content_ = JSON.stringify(id);
-
         let options_: RequestInit = {
-            body: content_,
             method: "DELETE",
             headers: {
-                "Content-Type": "application/json",
                 "Accept": "application/json"
             }
         };
@@ -373,13 +373,13 @@ export class BookClient {
         });
     }
 
-    protected processDeleteBook(response: Response): Promise<Book> {
+    protected processDeleteBook(response: Response): Promise<BaseBookResponse> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
-            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as Book;
+            result200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as BaseBookResponse;
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -387,7 +387,7 @@ export class BookClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<Book>(null as any);
+        return Promise.resolve<BaseBookResponse>(null as any);
     }
 }
 
@@ -416,6 +416,7 @@ export interface Book {
     pages?: number;
     createdat?: string | undefined;
     genreid?: string | undefined;
+    description?: string | undefined;
     genre?: Genre | undefined;
     authors?: Author[];
 }
@@ -437,6 +438,7 @@ export interface BaseBookResponse {
     pages?: number;
     createAt?: string | undefined;
     genreid?: string | undefined;
+    description?: string | undefined;
     authorsIDs?: string[];
 }
 
@@ -444,11 +446,17 @@ export interface CreateBookDto {
     title?: string;
     pages?: number;
     genreid?: string | undefined;
+    description?: string | undefined;
     authorsIDs?: string[];
 }
 
 export interface UpdateBookDto {
     id: string;
+    title?: string;
+    pages?: number;
+    genreid?: string | undefined;
+    description?: string | undefined;
+    authorsIDs?: string[];
 }
 
 export class ApiException extends Error {

--- a/server/services/BookService.cs
+++ b/server/services/BookService.cs
@@ -74,8 +74,13 @@ public class BookService(MyDbContext db) : IService<BaseBookResponse, CreateBook
         return new BaseBookResponse(currentBook);
     }
 
-    public Task<BaseBookResponse> Delete(string id)
+    public async Task<BaseBookResponse> Delete(string id)
     {
-        throw new NotImplementedException();
+        var book = db.Books.First(b => b.Id == id);
+        db.Books.Remove(book);
+
+        await db.SaveChangesAsync();
+
+        return new BaseBookResponse(book);
     }
 }


### PR DESCRIPTION
Updated the DeleteBook endpoint to accept the book ID as a query parameter and return a BaseBookResponse instead of Book. Adjusted OpenAPI spec, client code, and service implementation to match the new contract. Added 'description' field to relevant DTOs and models for improved book metadata support.